### PR TITLE
Allow sourcemapAsObject option

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,14 @@ module.exports = function(src, options, toStringOptions) {
     .use(namespace(options.namespace, options.namespaceOptions))
     .toString(toStringOptions);
 
-  css = autoprefixer().process(css).css;
+  // Process css as object
+  if (options.sourcemapAsObject) {
+    css.code = autoprefixer().process(css.code).css;
+  }
+  // Process as string
+  else {
+    css = autoprefixer().process(css).css;
+  }
 
   return css;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "basswork",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "author": "Brent Jackson",
   "license": "MIT",
   "bin": {


### PR DESCRIPTION
Basswork throws an error when setting [sourcemapAsObject](https://github.com/reworkcss/rework#reworktostringoptions) to true because the autoprefixer expects `css` to be a string. This patch returns a processed object or string based on this setting.

This option will allow me to setup source maps correctly in my Meteor package.