### PR TITLE
switch from options -> toStringOptions

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ module.exports = function(src, options, toStringOptions) {
     .toString(toStringOptions);
 
   // Process css as object
-  if (options.sourcemapAsObject) {
+  if (toStringOptions.sourcemapAsObject) {
     css.code = autoprefixer().process(css.code).css;
   }
   // Process as string


### PR DESCRIPTION
A little update to save having to declare the option twice, as it is more robust to depend solely on the toStringOptions.
